### PR TITLE
Add support for ADS1115

### DIFF
--- a/examples/read-all.py
+++ b/examples/read-all.py
@@ -10,9 +10,17 @@ Press Ctrl+C to exit!
 """)
 
 ads1015 = ADS1015()
+chip_type = ads1015.detect_chip_type()
+
+print("Found: {}".format(chip_type))
+
 ads1015.set_mode('single')
 ads1015.set_programmable_gain(2.048)
-ads1015.set_sample_rate(1600)
+
+if chip_type == 'ADS1015':
+    ads1015.set_sample_rate(1600)
+else:
+    ads1015.set_sample_rate(860)
 
 reference = ads1015.get_reference_voltage()
 

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -12,6 +12,11 @@ def test_setup_invalid_i2c_address(ads1015, mocksmbus):
         del device
 
 
+def test_autodetect(ads1015, smbus_notimeout):
+    device = ads1015.ADS1015()
+    assert device.detect_chip_type() == 'ADS1015'
+
+
 def test_timeout(ads1015, smbus_timeout):
     device = ads1015.ADS1015()
     with pytest.raises(ads1015.ADS1015TimeoutError):


### PR DESCRIPTION
Since the ADS1015 and ADS1115 are *very* similar this change adds support for the latter.

The ADS1115 uses a different set of sample rates to the ADS1015 and supports 16-bit data output.

An auto-detect function is supplied that uses the average timing of a set of ADC reads in order to detect which device is connected and adjust the library accordingly.