### PR TITLE
Make `get_voltage` thread safe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ UNSTABLE=false
 CODENAME=`lsb_release -sc`
 
 if [[ $CODENAME == "bullseye" ]]; then
-	bash ./install-bullseye.sh
+	bash ./install-bullseye.sh $@
 	exit $?
 fi
 

--- a/library/CHANGELOG.txt
+++ b/library/CHANGELOG.txt
@@ -1,3 +1,8 @@
+0.0.8
+-----
+
+* Add thread-safe wrapper around ADC reads
+
 0.0.7
 -----
 

--- a/library/README.md
+++ b/library/README.md
@@ -20,6 +20,11 @@ Latest/development library from GitHub:
 
 # Changelog
 
+0.0.8
+-----
+
+* Add thread-safe wrapper around ADC reads
+
 0.0.7
 -----
 

--- a/library/ads1015/__init__.py
+++ b/library/ads1015/__init__.py
@@ -2,6 +2,9 @@ from i2cdevice import Device, Register, BitField, _int_to_bytes
 from i2cdevice.adapter import Adapter, LookupAdapter
 import time
 import struct
+from functools import wraps
+from threading import Lock
+
 
 __version__ = '0.0.7'
 
@@ -60,8 +63,19 @@ class Conv16Adapter(Adapter):
         return 0
 
 
+def synchronized(func):
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with self._lock:
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
+
 class ADS1015:
     def __init__(self, i2c_addr=I2C_ADDRESS_DEFAULT, alert_pin=None, i2c_dev=None):
+        self._lock = Lock()
         self._is_setup = False
         self._i2c_addr = i2c_addr
         self._i2c_dev = i2c_dev
@@ -155,6 +169,7 @@ class ADS1015:
         ))
         self._ads1015.select_address(self._i2c_addr)
 
+    @synchronized
     def detect_chip_type(self, timeout=10.0):
         """Attempt to auto-detect if an ADS1015 or ADS1115 is connected."""
         # 250sps is 16sps on ADS1115
@@ -337,6 +352,7 @@ class ADS1015:
         """Read the reference voltage that is included on the pimoroni PM422 breakout."""
         return self.get_voltage(channel='in3/gnd')
 
+    @synchronized
     def get_voltage(self, channel=None):
         """Read the raw voltage of a channel."""
         if channel is not None:

--- a/library/ads1015/__init__.py
+++ b/library/ads1015/__init__.py
@@ -6,7 +6,7 @@ from functools import wraps
 from threading import Lock
 
 
-__version__ = '0.0.7'
+__version__ = '0.0.8'
 
 DEVICE_ADS1015 = 'ADS1015'
 DEVICE_ADS1115 = 'ADS1115'

--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 [metadata]
 name = ads1015
-version = 0.0.7
+version = 0.0.8
 author = Philip Howard
 author_email = phil@pimoroni.com
 description = Python library for the ADS1015 and ADS1115 4-channel ADC


### PR DESCRIPTION
This change is mostly so that Automation HAT can incorporate this library rather than its own, cut-down vendored alternative.

Prerequisite for: https://github.com/pimoroni/automation-hat/pull/48

The lock added here prevents ADC reads from clobbering each other.