### PR TITLE
fixed loop timing

### DIFF
--- a/ads1015/__init__.py
+++ b/ads1015/__init__.py
@@ -250,14 +250,14 @@ class ADS1015:
         runtimes = []
         for x in range(samples):
             self.start_conversion()
-            t_start = time.time()
+            t_start = time.monotonic()
 
             while self._ads1015.get("CONFIG").operational_status == "active":
-                if (time.time() - t_start) > timeout:
+                if (time.monotonic() - t_start) > timeout:
                     raise ADS1015TimeoutError("Timed out waiting for conversion.")
                 time.sleep(0.001)
 
-            runtimes.append(time.time() - t_start)
+            runtimes.append(time.monotonic() - t_start)
             time.sleep(0.001)
 
         runtime = sum(runtimes) / float(samples)
@@ -412,10 +412,10 @@ class ADS1015:
         :raises socket.timeout in Python 2.x
 
         """
-        t_start = time.time()
+        t_start = time.monotonic()
         while not self.conversion_ready():
             time.sleep(0.001)
-            if (time.time() - t_start) > timeout:
+            if (time.monotonic() - t_start) > timeout:
                 raise ADS1015TimeoutError("Timed out waiting for conversion.")
 
     def get_reference_voltage(self):


### PR DESCRIPTION
`time.time()` is susceptible to ntp adjustments. Use `.monotonic()` to avoid it.

In the rare case where the OS adjusts the time forward while waiting for conversion, it will raise `ADS1015TimeoutError`.

This might explain the occasional `ADS1015TimeoutError` exception I get. Source: [#63](https://github.com/pimoroni/automation-hat/issues/63)